### PR TITLE
makefile: remove commented CFLAGS

### DIFF
--- a/config.mk
+++ b/config.mk
@@ -21,7 +21,6 @@ LIBS = -L${X11LIB} -lX11 ${XINERAMALIBS} ${FREETYPELIBS} -lImlib2
 
 # flags
 CPPFLAGS = -D_DEFAULT_SOURCE -D_BSD_SOURCE -D_POSIX_C_SOURCE=2 ${XINERAMAFLAGS} ${WALLPAPER}
-#CFLAGS   = -g -std=c99 -pedantic -Wall -O0 ${INCS} ${CPPFLAGS}
 CFLAGS   = -std=c99 -pedantic -Wall -Wno-deprecated-declarations -Os ${INCS} ${CPPFLAGS}
 LDFLAGS  = -s ${LIBS}
 


### PR DESCRIPTION
Commented code is often useless distraction.
Read:
http://softwareengineering.stackexchange.com/questions/45378/is-commented-out-code-really-always-bad

And according to Clean Code:
> Few practices are as odious as commenting-out code. Don't do this!.

Signed-off-by: Mattijs Korpershoek <mattijs.korpershoek@gmail.com>